### PR TITLE
Fix fullscreen bounds calculation

### DIFF
--- a/src/main/windows/index.ts
+++ b/src/main/windows/index.ts
@@ -74,8 +74,8 @@ export const getCenteredCoordinates = (w: number, h: number) => {
   const cursorScreen = getCurrentScreen();
   const { width, height } = cursorScreen.workAreaSize;
   return {
-    x: cursorScreen.bounds.x + Math.round((width - w) / 2),
-    y: cursorScreen.bounds.y + Math.round(Math.max(height/5, (height - h) / 3)),
+    x: cursorScreen.workArea.x + Math.round((width - w) / 2),
+    y: cursorScreen.workArea.y + Math.round(Math.max(height/5, (height - h) / 3)),
   };
 };
 
@@ -89,7 +89,7 @@ export const getFullscreenBounds = (screen: Display): { x: number, y: number, wi
   const y = screen.workArea.y - 1;
   return {
     x, y,
-    width: screen.bounds.width - x,
+    width: screen.workArea.width,
     height: screen.bounds.height - y,
   }
 }

--- a/tests/unit/window.test.ts
+++ b/tests/unit/window.test.ts
@@ -375,3 +375,32 @@ test('Notify', async () => {
   window.notifyBrowserWindows('event')
   expect(BrowserWindow.prototype.webContents.send).toHaveBeenCalledWith('event')
 })
+
+test('Fullscreen bounds for secondary screen', async () => {
+  const display = {
+    bounds: { x: 1920, y: 0, width: 1920, height: 1080 },
+    workArea: { x: 1920, y: 23, width: 1920, height: 1057 },
+  } as any
+
+  const bounds = window.getFullscreenBounds(display)
+  expect(bounds).toEqual({
+    x: 1920,
+    y: 22,
+    width: 1920,
+    height: 1080 - 22,
+  })
+})
+
+test('Centered coordinates respect workArea', async () => {
+  (window.getCurrentScreen as unknown as Mock).mockReturnValue({
+    bounds: { x: 0, y: 0, width: 1920, height: 1080 },
+    workArea: { x: 80, y: 23, width: 1840, height: 1057 },
+    workAreaSize: { width: 1840, height: 1057 },
+  })
+
+  const coords = window.getCenteredCoordinates(800, 600)
+  expect(coords).toEqual({
+    x: 80 + Math.round((1840 - 800) / 2),
+    y: 23 + Math.round(Math.max(1057 / 5, (1057 - 600) / 3)),
+  })
+})


### PR DESCRIPTION
## Summary
- fix window centering with docks by using screen.workArea coordinates
- add unit test for centered coordinates relative to workArea
- re-check fullscreen bounds for secondary displays

## Testing
- `npx vitest` *(fails: vitest missing due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_68583fecea3883229a927c55153e9298